### PR TITLE
Two things

### DIFF
--- a/lib/dwca-hunter/resource_itis.rb
+++ b/lib/dwca-hunter/resource_itis.rb
@@ -51,7 +51,7 @@ class DwcaHunter
       f.each do |l|
         l.encode!('UTF-8', 'ISO-8859-1', :invalid => :replace, :replace => '?')
         row = l.strip.split("|")
-        @ranks[row[1].strip] = row[2].strip
+        @ranks[row[0].strip + '/' + row[1].strip] = row[2].strip
       end
     end
 
@@ -161,13 +161,14 @@ class DwcaHunter
         status     = data[10]
         parent_tsn = data[17]
         author_id  = data[18]
+        kingdom_id = data[20]
         rank_id    = data[21]
 
         parent_tsn = nil if parent_tsn == ''
         name = [x1, name_part1, x2, name_part2, sp_marker1, name_part3, sp_marker2, name_part4]
         name << @authors[author_id] if @authors[author_id] 
         name = name.join(' ').strip.gsub(/\s+/, ' ')
-        rank = @ranks[rank_id] ? @ranks[rank_id] : ''
+        rank = @ranks[kingdom_id + '/' + rank_id] ? @ranks[kingdom_id + '/' + rank_id] : ''
         @names[name_tsn] = { name:name, status:status, parent_tsn:parent_tsn, rank:rank } 
       end
     end


### PR DESCRIPTION
I've modified resource_itis.rb so that it:
(1) create a blank "version_<original directory name>" file in the /tmp/dwca_hunter/itis/itis directory; this is because ITIS encodes the version number into the original directory name (it is in the format "itisMySQL062712", where the last six digits are the database creation date in MMDDYY). That way, my itis-dwca script -- or any other script -- can figure out when the database file was created, so it can report on exactly which version of ITIS you're working with.
(2) Fixed https://github.com/GlobalNamesArchitecture/dwca-hunter/issues/1 (I think).

Hope that helps! Please let me know if I'm going about pull requests wrong!
